### PR TITLE
配送先編集画面の作成

### DIFF
--- a/app/controllers/customer/deliveries_controller.rb
+++ b/app/controllers/customer/deliveries_controller.rb
@@ -7,17 +7,24 @@ class Customer::DeliveriesController < ApplicationController
 
   def create
     @delivery = Delivery.new(delivery_params)
-    @delivery.save!
-    redirect_to deliveries_path(@delivery)
+    @delivery.save
+    redirect_to deliveries_path(@delivery.id)
   end
 
   def edit
+    @delivery = Delivery.find(params[:id])
   end
 
   def update
+    @delivery = List.find(params[:id])
+    @delivery.update(delivery_params)
+    redirect_to deliveries_path(@delivery.id)
   end
 
   def destroy
+    delivery = Delivery.find(params[:id])
+    delivery.destroy
+    redirect_to deliveries_path(@delivery.id)
   end
 
   private

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -5,6 +5,6 @@ class Delivery < ApplicationRecord
   validates :postcode, presence: true
   validates :address, presence: true
 
-  belongs_to :customer
+  belongs_to :customer, optional: true
 
 end

--- a/app/views/customer/deliveries/edit.html.erb
+++ b/app/views/customer/deliveries/edit.html.erb
@@ -1,1 +1,11 @@
-deliveries#edit
+<h2>配送先編集</h2>
+
+<%= form_for(@delivery) do |f| %>
+    <h4>郵便番号(ハイフンなし)</h4>
+    <%= f.text_field :postcode %>
+    <h4>住所</h4>
+    <%= f.text_field :address %>
+    <h4>宛名</h4>
+    <%= f.text_field :name %>
+    <%= f.submit '配送する' %>
+<% end %>

--- a/app/views/customer/deliveries/index.html.erb
+++ b/app/views/customer/deliveries/index.html.erb
@@ -1,7 +1,7 @@
 <h2>配送先登録 / 一覧</h2>
 
 <%= form_for(@delivery) do |f| %>
-    <h4>郵便番号</h4>
+    <h4>郵便番号(ハイフンなし)</h4>
     <%= f.text_field :postcode %>
     <h4>住所</h4>
     <%= f.text_field :address %>
@@ -25,6 +25,8 @@
 				<td><%= delivery.postcode %></td>
 				<td><%= delivery.address %></td>
 				<td><%= delivery.name %></td>
+				<td><%= link_to '編集する', edit_delivery_path(@delivery.id) %></td>
+				<td><%= link_to '削除する', delivery_path(@delivery.id),method: :delete, "date-confirm" => "削除しますか？" %></td>
 			</tr>
 		<% end %>
 	</tbody>


### PR DESCRIPTION
配送先編集画面を作成しました。
また配送先一覧機能に編集画面へのリンク、削除ボタンを配置しました。
投稿データが一覧に載らないというエラーが出てますがアソシエーションしている会員情報がないためだと考えています。